### PR TITLE
fix: Ignore comments without template actions

### DIFF
--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -1,0 +1,7 @@
+# ToC
+<!--- {{ toc }} --->
+
+
+# test
+## test ok
+### hallo

--- a/cmd/mdtmpl.go
+++ b/cmd/mdtmpl.go
@@ -146,6 +146,7 @@ func parse(r io.Reader, opts ...template.RendererOptions) ([]byte, error) {
 				return nil, err
 			} else if !containsActions {
 				ln++
+
 				continue
 			}
 

--- a/cmd/mdtmpl_test.go
+++ b/cmd/mdtmpl_test.go
@@ -56,6 +56,12 @@ password=password
 
 `,
 		},
+		{
+			name: "regularComment",
+			tmpl: `<!--- regular comment --->`,
+			exp: `<!--- regular comment --->
+`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -180,7 +180,7 @@ func Render(content []byte, vars interface{}, opts ...RendererOptions) (bytes.Bu
 	return buf, nil
 }
 
-// Determines if content has template statements
+// Determines if content has template statements.
 func ContainsTemplateActions(content []byte, opts ...RendererOptions) (bool, error) {
 	handler := sprout.New()
 	if err := handler.AddGroups(all.RegistryGroup()); err != nil {
@@ -195,6 +195,7 @@ func ContainsTemplateActions(content []byte, opts ...RendererOptions) (bool, err
 	return containsTemplateActions(tpl.Tree.Root), nil
 }
 
+// nolint: funlen
 func newTemplate(content []byte, handler *sprout.DefaultHandler, opts ...RendererOptions) (*template.Template, error) {
 	var r Renderer
 
@@ -283,5 +284,6 @@ func containsTemplateActions(n parse.Node) bool {
 		*parse.WithNode, *parse.TemplateNode, *parse.BranchNode:
 		return true
 	}
+
 	return false
 }

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -132,3 +132,108 @@ echo hallo
 		})
 	}
 }
+
+func TestTemplateStatements(t *testing.T) {
+	testcases := []struct {
+		name string
+		opts []RendererOptions
+		tmpl string
+		exp  bool
+		err  bool
+	}{
+		{
+			name: "simple render",
+			tmpl: `{{ .Key }}`,
+			exp:  true,
+		},
+		{
+			name: "truncate",
+			tmpl: `{{ "this is a line\n" | truncate }}`,
+			exp:  true,
+		},
+		{
+			name: "truncate multiple lines",
+			tmpl: `{{ "this is a line\n\n\n" | truncate }}`,
+			exp:  true,
+		},
+		{
+			name: "truncate multiple lines",
+			tmpl: `{{ "this is a line\n\n\n" | truncate }}`,
+			exp:  true,
+		},
+		{
+			name: "stripansi",
+			tmpl: `{{ "\x1b[38;5;140mfoo\x1b[0m bar" | stripansi }}`,
+			exp:  true,
+		},
+		{
+			name: "exec & code",
+			tmpl: `{{ exec "echo hallo" | truncate | code "bash" }}`,
+			exp:  true,
+		},
+		{
+			name: "hook",
+			tmpl: `{{ hook "echo hallo" }}`,
+			exp:  true,
+		},
+		{
+			name: "toc",
+			opts: []RendererOptions{WithTemplateFile("testdata/toc.md")},
+			tmpl: `# ToC
+{{ toc }}
+# 1. Heading
+## 2. Heading
+### 3. Heading
+## 5. Heading`,
+			exp: true,
+		},
+		{
+			name: "file",
+			tmpl: `This is text
+{{ file "testdata/include.md" }}`,
+			exp: true,
+		},
+		{
+			name: "tmpl",
+			tmpl: `This is text
+{{ tmpl "testdata/tmpl.tmpl" }}`,
+			exp: true,
+		},
+		{
+			name: "tmpl with vars",
+			tmpl: `This is text
+{{ tmplWithVars "./testdata/tmpl-vars.tmpl" (file "./testdata/values.yml" | fromYAML) }}`,
+			exp: true,
+		},
+		{
+			name: "collapsile",
+			tmpl: `{{ collapsile "details" (code "bash" "echo hallo") }}`,
+			exp:  true,
+		},
+		{
+			name: "plain text",
+			tmpl: "example text",
+			exp:  false,
+		},
+		{
+			name: "markdown comment",
+			tmpl: "<!--- example comment --->",
+			exp:  false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := ContainsTemplateActions([]byte(tc.tmpl), tc.opts...)
+
+			if tc.err {
+				require.Error(t, err, "expected an error but did not get one")
+
+				return
+			}
+
+			require.NoError(t, err, "expected no error but got one")
+			require.Equal(t, tc.exp, out)
+		})
+	}
+}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -133,6 +133,7 @@ echo hallo
 	}
 }
 
+// nolint: funlen
 func TestTemplateStatements(t *testing.T) {
 	testcases := []struct {
 		name string


### PR DESCRIPTION
fixes https://github.com/FalcoSuessgott/mdtmpl/issues/15

## Add `ContainsTemplateActions` template function

Addition of `ContainsTemplateActions` template util function that return `true` if content contains template actions and `false` if content does not contain template actions. Also has the addition of other private helper functions for `ContainsTemplateActions`, including `newTemplate` to create the template entity needed for both `ContainsTemplateActions` and `Render`.

## Skip comments without template actions

mdtmpl now skips comments without template actions using newly added `ContainsTemplateActions` template util function.
